### PR TITLE
Guess screen resolutions from text

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,19 @@ $ npm install --save screensize
 
 ```js
 var screensize = require('screensize');
-var dimensions = screensize.calculate(5.70, 2560, 1440);
 
-/*
- * dimensions
- *   .width = 4.96798...
- *   .height = 2.79449...
- */
+screensize.calculate(5.70, 2560, 1440);
+// {width: 4.96798..., height: 2.79449...}
+
+var screen = screensize.guess('Full HD, 21.5 inches');
+screen.widthIn('in');    // 18.74 inches
+screen.diagonalIn('cm'); // 54.61 centimeters
+screen.pixelsPer('in');  // 102.46 pixels per inch
+screen.pixelsPer('mm');  // 4.03 pixels per millimeter
 ```
+
+Supported units: m, dm, cm, mm, in, px.
+
 ## License
 
 MIT © [Nikolay Kim]()

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Take a diagonal in any length unit and resX / resY in pixels, as the width
+// and height of the screen, respectively.
+// Return {width, height} of the screen in the same unit as diagonal.
 var calculate = function (diagonal, resX, resY) {
   var pixelsInDiagonal = Math.sqrt(Math.pow(resX, 2) + Math.pow(resY, 2));
   var unitsPerPixel = diagonal / pixelsInDiagonal;
@@ -10,6 +13,178 @@ var calculate = function (diagonal, resX, resY) {
   };
 };
 
+var meterPerInch = 0.0254;
+var meterFromInch = function (length) {
+  return length * meterPerInch;
+};
+var inchFromMeter = function (length) {
+  return length / meterPerInch;
+};
+
+// width, height: screen resolution in pixels.
+// diagonal: screen diagonal length in meters.
+var Screen = function (width, height, diagonal) {
+  this.width = width;
+  this.height = height;
+  this.diagonal = diagonal;
+};
+
+Screen.prototype = {
+  // Pixels per meter.
+  ppm: function () {
+    var diagpx = Math.sqrt(this.width * this.width + this.height * this.height);
+    return diagpx / this.diagonal;
+  },
+  pixelsPer: function (unit) {
+    switch (unit) {
+      case 'm': return this.ppm();
+      case 'dm': return this.ppm() / 10;
+      case 'cm': return this.ppm() / 100;
+      case 'mm': return this.ppm() / 1000;
+      case 'in': return this.ppm() * meterPerInch;
+      case 'px': return 1;
+    }
+  },
+  diagonalIn: function (unit) {
+    switch (unit) {
+      case 'm': return this.diagonal;
+      case 'dm': return this.diagonal * 10;
+      case 'cm': return this.diagonal * 100;
+      case 'mm': return this.diagonal * 1000;
+      case 'in': return inchFromMeter(this.diagonal);
+      case 'px': return this.ppm() * this.diagonal;
+    }
+  },
+  widthIn: function (unit) {
+    switch (unit) {
+      case 'm': return this.width / this.ppm();
+      case 'dm': return this.width / this.ppm() * 10;
+      case 'cm': return this.width / this.ppm() * 100;
+      case 'mm': return this.width / this.ppm() * 1000;
+      case 'in': return inchFromMeter(this.width / this.ppm());
+      case 'px': return this.width;
+    }
+  },
+  heightIn: function (unit) {
+    switch (unit) {
+      case 'm': return this.height / this.ppm();
+      case 'dm': return this.height / this.ppm() * 10;
+      case 'cm': return this.height / this.ppm() * 100;
+      case 'mm': return this.height / this.ppm() * 1000;
+      case 'in': return inchFromMeter(this.height / this.ppm());
+      case 'px': return this.height;
+    }
+  }
+};
+
+// Larger number of lines first, unless justified.
+// Source: https://en.wikipedia.org/wiki/Graphics_display_resolution
+var formats = [
+  { re: /\bwhuxga\b/i, v: { width: 7680, height: 4800 } },
+  { re: /\bhuxga\b/i, v: { width: 6400, height: 4800 } },
+  { re: /\b(8k\b|uhdtv-2)/i, v: { width: 7680, height: 4320 } },
+  { re: /\bwhsxga\b/i, v: { width: 6400, height: 4096 } },
+  { re: /\bhsxga\b/i, v: { width: 5120, height: 4096 } },
+  { re: /\bwhxga\b/i, v: { width: 5120, height: 3200 } },
+  { re: /\bhxga\b/i, v: { width: 4096, height: 3072 } },
+  { re: /\b(5k\b|uhd\+)/i, v: { width: 5120, height: 2880 } },
+  { re: /\bwquxga\b/i, v: { width: 3840, height: 2400 } },
+  { re: /\bquxga\b/i, v: { width: 3200, height: 2400 } },
+  { re: /\b(dci|cinema)\s+4k\b/i, v: { width: 4096, height: 2160 } },
+  { re: /\b(4k|uhd|ultra\s+hd|uhdtv)\b/i, v: { width: 3840, height: 2160 } },
+  { re: /\bwqsxga\b/i, v: { width: 3200, height: 2048 } },
+  { re: /\bqsxga\b/i, v: { width: 2560, height: 2048 } },
+  { re: /\bqHD\b/, v: { width: 960, height: 540 } },  // collision with QHD.
+  { re: /\b(qhd\+|wqxga\+)/i, v: { width: 3200, height: 1800 } },
+  { re: /\bwqxga\b/i, v: { width: 2560, height: 1600 } },
+  { re: /\bqxga\b/i, v: { width: 2048, height: 1536 } },
+  { re: /\buwqhd\b/i, v: { width: 3440, height: 1440 } },
+  { re: /\b(qhd|quad\s+hd|wqhd|wide\s+quad\s+hd)\b/i, v: { width: 2560, height: 1440 } },
+  { re: /\bfull\s+hd(\+|\s+plus\b)/i, v: { width: 2560, height: 1440 } },
+  { re: /\b1440[pi]\b/, v: { width: 2560, height: 1440 } },
+  { re: /\bwuxga\b/i, v: { width: 1920, height: 1200 } },
+  { re: /\buxga\b/i, v: { width: 1600, height: 1200 } },
+  { re: /\bqwxga\b/i, v: { width: 2048, height: 1152 } },
+  { re: /\buw-uxga\b/i, v: { width: 2560, height: 1080 } },
+  { re: /\b2k\b/i, v: { width: 2048, height: 1080 } },
+  { re: /\bfhd\b/i, v: { width: 1920, height: 1080 } },
+  { re: /\bfull\s+hd\b/i, v: { width: 1920, height: 1080 } },
+  { re: /\b1080[pi]\b/, v: { width: 1920, height: 1080 } },
+  { re: /\bwsxga\+/i, v: { width: 1680, height: 1050 } },
+  { re: /\bsxga\+/i, v: { width: 1400, height: 1050 } },
+  { re: /\bwsxga/i, v: { width: 1600, height: 1024 } },
+  { re: /\bsxga/i, v: { width: 1280, height: 1024 } },
+  { re: /\bfwxga(\+|\s+plus)/i, v: { width: 1440, height: 960 } },
+  { re: /\buvga\b/i, v: { width: 1280, height: 960 } },
+  { re: /\bhd(\+|\s+plus\b)/i, v: { width: 1600, height: 900 } },
+  { re: /\b(wsxga\b|wxga\+)/i, v: { width: 1440, height: 900 } },
+  { re: /\bxga\+/i, v: { width: 1152, height: 864 } },
+  { re: /\b(wxga|wide\s+xga|fwxga)\b/i, v: { width: 1366, height: 768 } },
+  { re: /\bxga\b/i, v: { width: 1024, height: 768 } },
+  { re: /\b(hd|hdtv)\b/i, v: { width: 1280, height: 720 } },
+  { re: /\b720[pi]\b/, v: { width: 1280, height: 720 } },
+  { re: /\b(dvga|double-size\s+vga)\b/i, v: { width: 960, height: 640 } },
+  { re: /\b(svga|super\s+vga|uvga|ultra\s+vga)\b/i, v: { width: 800, height: 600 } },
+  { re: /\b(wsvga|wide\s+super\s+vga)\b/i, v: { width: 1024, height: 576 } },
+  { re: /\b576[pi]\b/, v: { width: 720, height: 576 } },
+  { re: /\bfwvga\b/i, v: { width: 854, height: 480 } },
+  { re: /\b(wvga|wide\s+vga|wga)\b/i, v: { width: 768, height: 480 } },
+  { re: /\b480[pi]\b/, v: { width: 720, height: 480 } },
+  { re: /\b(sdtv|edtv)\b/i, v: { width: 720, height: 480 } },
+  { re: /\bvga\b/i, v: { width: 640, height: 480 } },
+  { re: /\bnHD\b/, v: { width: 640, height: 360 } },
+  { re: /\b(mda|hgc)\b/i, v: { width: 720, height: 350 } },
+  { re: /\bega\b/i, v: { width: 640, height: 350 } },
+  { re: /\bhvga\b/i, v: { width: 480, height: 320 } },
+  { re: /\bfwqvga\b/i, v: { width: 432, height: 240 } },
+  { re: /\bwqvga\b/i, v: { width: 360, height: 240 } },
+  { re: /\bqvga\b/i, v: { width: 320, height: 240 } },
+  { re: /\bcga\b/i, v: { width: 320, height: 200 } },
+  { re: /\bhqvga\b/i, v: { width: 240, height: 160 } },
+  { re: /\bqqvga\b/i, v: { width: 160, height: 120 } }
+];
+
+var guessPixels = function (text, screen) {
+  // Try to find exact pixel values.
+  var match = /([\d\s]+)(?:px|pixels?)?\s*(?:[xX×]|by|par)\s*([\d\s]+)(?:px|pixels?)?/.exec(text);
+  if (match != null) {
+    screen.width = +match[1].replace(/\s/g, '');
+    screen.height = +match[2].replace(/\s/g, '');
+    return screen;
+  }
+  // Try to find a format.
+  for (var i = 0, len = formats.length; i < len; i++) {
+    if (formats[i].re.test(text)) {
+      screen.width = formats[i].v.width;
+      screen.height = formats[i].v.height;
+      return screen;
+    }
+  }
+  return screen;
+};
+
+var guessDiagonal = function (text, screen) {
+  var match = /(\d+)(?:[,.](\d+))?\s*(?:in\b|inch\b|inches|"|″|''|’’|pouces?\b)/.exec(text);
+  if (match != null) {
+    var inchdec = +match[2];
+    if (inchdec !== inchdec) {
+      inchdec = '0';
+    }
+    var inches = +(match[1] + '.' + inchdec);
+    screen.diagonal = meterFromInch(inches);
+  }
+  return screen;
+};
+
+// Input a textual description of the screen, output a Screen.
+var guess = function (text) {
+  var screen = new Screen(0, 0, 0);
+  guessPixels(text, screen);
+  guessDiagonal(text, screen);
+  return screen;
+};
+
 module.exports = {
-  calculate: calculate
+  calculate: calculate,
+  guess: guess
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "files": [
     "lib"
   ],
-  "main": "lib\\index.js",
+  "main": "lib/index.js",
   "keywords": [
     "screen",
     "size",

--- a/test/index.js
+++ b/test/index.js
@@ -9,11 +9,42 @@ function runTest(diagonal, resX, resY, width, height, precision) {
   assert.equal(height.toPrecision(precision), s.height.toPrecision(precision));
 }
 
+function checkNumbers(value0, value1) {
+  assert.equal(value0.toFixed(2), value1.toFixed(2));
+}
+
 describe('screensize', function () {
   it('Nokia 105', function () {
     runTest(1.36, 68, 96, 0.78610, 1.10979, 5);
   });
   it('Huawei Nexus 6P', function () {
     runTest(5.70, 2560, 1440, 4.96798, 2.79449, 5);
+  });
+  it('Full HD, 21.5 inches', function () {
+    var screen = screensize.guess('Full HD, 21.5 inches');
+    checkNumbers(screen.widthIn('m'), 0.48);
+    checkNumbers(screen.widthIn('dm'), 4.76);
+    checkNumbers(screen.widthIn('cm'), 47.60);
+    checkNumbers(screen.widthIn('mm'), 475.97);
+    checkNumbers(screen.widthIn('in'), 18.74);
+    checkNumbers(screen.widthIn('px'), 1920);
+    checkNumbers(screen.heightIn('m'), 0.27);
+    checkNumbers(screen.heightIn('dm'), 2.68);
+    checkNumbers(screen.heightIn('cm'), 26.77);
+    checkNumbers(screen.heightIn('mm'), 267.73);
+    checkNumbers(screen.heightIn('in'), 10.54);
+    checkNumbers(screen.heightIn('px'), 1080);
+    checkNumbers(screen.diagonalIn('m'), 0.55);
+    checkNumbers(screen.diagonalIn('dm'), 5.46);
+    checkNumbers(screen.diagonalIn('cm'), 54.61);
+    checkNumbers(screen.diagonalIn('mm'), 546.1);
+    checkNumbers(screen.diagonalIn('in'), 21.5);
+    checkNumbers(screen.diagonalIn('px'), 2202.91);
+    checkNumbers(screen.pixelsPer('m'), 4033.89);
+    checkNumbers(screen.pixelsPer('dm'), 403.39);
+    checkNumbers(screen.pixelsPer('cm'), 40.34);
+    checkNumbers(screen.pixelsPer('mm'), 4.03);
+    checkNumbers(screen.pixelsPer('in'), 102.46);
+    checkNumbers(screen.pixelsPer('px'), 1.00);
   });
 });


### PR DESCRIPTION
```js
var screensize = require('screensize');

var screen = screensize.guess('Full HD, 21.5 inches');
screen.widthIn('in');    // 18.74 inches
screen.diagonalIn('cm'); // 54.61 centimeters
screen.pixelsPer('in');  // 102.46 pixels per inch
screen.pixelsPer('mm');  // 4.03 pixels per millimeter
```

Supported units: m, dm, cm, mm, in, px.

This patch opens up the ability to have a website / CLI / bot which can give screen information from a mere paste of screen data grabbed on the Web.

(Prototyping demo: https://thefiletree.com/espadrine/%E2%9A%92/screen-size.html)